### PR TITLE
Use application repo for list_tenants

### DIFF
--- a/lib/tenantex.ex
+++ b/lib/tenantex.ex
@@ -5,7 +5,14 @@ defmodule Tenantex do
   defdelegate drop_tenant(repo, tenant), to: Tenantex.Repo
   defdelegate new_tenant(repo, tenant), to: Tenantex.Repo
 
-  def list_tenants, do: list_tenants(Application.get_env(:tenantex, Tenantex)[:tenants])
+  def list_tenants do
+    Mix.Project.config()[:app]
+      |> Application.get_env(:ecto_repos)
+      |> List.first()
+      |> Ecto.Adapters.SQL.query!("select schema_name from information_schema.schemata")
+      |> Map.fetch!(:rows)
+      |> Enum.filter_map(fn(schema) -> String.starts_with?(List.first(schema),Application.get_env(:tenantex, Tenantex)[:schema_prefix]) end, &(List.first(&1)) )
+  end
   defp list_tenants({module, func}), do: apply(module, func, [])
   defp list_tenants({module, func, args}), do: apply(module, func, args)
   defp list_tenants(tenants) when is_list(tenants), do: tenants


### PR DESCRIPTION
Get the live schema list from the db in order to resolve for list_tenants()
Utilize app configs as well as Tenantex :schema_prefix config to filter the schemas known to the db
Very large assumption here that the config for :ecto_repos is a single element list
Alternative would be to more directly assign the relevant repo name in another config option for Tenantex